### PR TITLE
Fix `@Redirect`s on game rules always using mobGriefing

### DIFF
--- a/src/main/java/fi/dy/masa/servux/mixin/entity/MixinAllayEntity.java
+++ b/src/main/java/fi/dy/masa/servux/mixin/entity/MixinAllayEntity.java
@@ -25,7 +25,7 @@ public abstract class MixinAllayEntity
 			return true;
 		}
 
-		return instance.getBoolean(GameRules.DO_MOB_GRIEFING);
+		return instance.getBoolean(rule);
 	}
 
 //	@Inject(method = "isItemPickupCoolingDown",

--- a/src/main/java/fi/dy/masa/servux/mixin/entity/MixinItemEntity.java
+++ b/src/main/java/fi/dy/masa/servux/mixin/entity/MixinItemEntity.java
@@ -41,6 +41,6 @@ public class MixinItemEntity
 		}
 
 		this.isAllay = false;
-		return instance.getBoolean(GameRules.DO_MOB_GRIEFING);
+		return instance.getBoolean(rule);
 	}
 }

--- a/src/main/java/fi/dy/masa/servux/mixin/entity/MixinMobEntity.java
+++ b/src/main/java/fi/dy/masa/servux/mixin/entity/MixinMobEntity.java
@@ -44,6 +44,6 @@ public abstract class MixinMobEntity
 		}
 
 		this.isAllay = false;
-		return instance.getBoolean(GameRules.DO_MOB_GRIEFING);
+		return instance.getBoolean(rule);
 	}
 }


### PR DESCRIPTION
Hi! You have some `@Redirect`s that target calls like `world.getBoolean(GameRules.DO_MOB_GRIEFING)` and where you also use `world.getBoolean(GameRules.DO_MOB_GRIEFING)` in the mixin method

This can cause incompatibilities with mods that use `@ModifyArg` on the same method (such as [Convenient mobGriefing](https://github.com/A5b84/convenient-mobgriefing), see https://github.com/A5b84/convenient-mobgriefing/issues/19) as the modified argument value is ignored

This PR just fixes that and it resolved the incompatibility when I tested it locally